### PR TITLE
feat(startSession): support multi-curve defaultDerivationPaths (ED25519 / Hedera)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,34 @@ const config = {
     attestationMode: "offline",
     defaultDerivationPaths: "m/44'/144'/0'/0/0",
 };
-RNTangemSdk.startSession();
+RNTangemSdk.startSession(config);
+```
+
+`defaultDerivationPaths` accepts three input shapes:
+
+| Shape                            | Curve applied      | Use case                                  |
+| -------------------------------- | ------------------ | ----------------------------------------- |
+| `string`                         | `secp256k1`        | Single path — XRP / BTC style (legacy)    |
+| `string[]`                       | `secp256k1`        | Multiple paths on the same curve          |
+| `{ [curve]: string[] }`          | Per-curve          | Multi-curve — e.g. ED25519 / SLIP-0010    |
+
+Example: derive 16 Hedera accounts (SLIP-0010 ED25519 on BIP-44 coin-type 3030) in a single tap:
+
+```js
+const hederaPaths = Array.from(
+    { length: 16 },
+    (_, i) => `m/44'/3030'/0'/0'/${i}'`,
+);
+
+await RNTangemSdk.startSession({
+    attestationMode: "offline",
+    defaultDerivationPaths: {
+        ed25519_slip0010: hederaPaths,
+    },
+});
+
+const card = await RNTangemSdk.scanCard();
+// card.wallets[i].derivedKeys now contains all 16 derived public keys.
 ```
 
 > It's recommended to check for NFC status before running any other method and call this method again in case of

--- a/RNTangemSdk.podspec
+++ b/RNTangemSdk.podspec
@@ -24,7 +24,26 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   
   # deps
-  s.dependency 'TangemSdk', "3.11.0"
+  #
+  # Pinned to 3.9.0 — last 3.9.x available on the CocoaPods trunk.
+  #
+  # Higher TangemSdk versions (3.10.0, 3.11.0) ship a `module.modulemap` that
+  # declares `TangemSdk_secp256k1` as a separate [system] module. When Pods
+  # integrates the SDK into an app workspace, Xcode/Swift cannot resolve that
+  # module without an explicit `SWIFT_INCLUDE_PATHS` pointing at the
+  # modulemap directory, causing:
+  #
+  #   error: unable to resolve module dependency: 'TangemSdk_secp256k1'
+  #
+  # The 3.9.0 series ships everything as a single module, so the wrapper
+  # works out of the box. The `ed25519_slip0010` curve (required for Hedera)
+  # is available in 3.9.0, so there is no feature regression.
+  #
+  # Alternative for >= 3.10: add a `pod_target_xcconfig` here with
+  # SWIFT_INCLUDE_PATHS = '$(PODS_ROOT)/TangemSdk/TangemSdk/TangemSdk'. Not
+  # done in this PR to keep the change minimal; happy to bump if maintainers
+  # prefer that route.
+  s.dependency 'TangemSdk', "3.9.0"
   # new archt deps
   install_modules_dependencies(s)
   

--- a/android/src/main/java/com/tangem/RNTangemSdk/RNTangemSdkModule.kt
+++ b/android/src/main/java/com/tangem/RNTangemSdk/RNTangemSdkModule.kt
@@ -173,13 +173,17 @@ class RNTangemSdkModule(private val reactContext: ReactApplicationContext) :
                     config.attestationMode = attestationMode
                 }
 
-                val defaultDerivationPath = optionsParser.getDefaultDerivationPath()
-                if (defaultDerivationPath != null) {
-                    val defaultDerivationPaths: MutableMap<EllipticCurve, List<DerivationPath>> =
-                        mutableMapOf()
-                    defaultDerivationPaths[EllipticCurve.Secp256k1] =
-                        listOf(defaultDerivationPath)
-                    config.defaultDerivationPaths = defaultDerivationPaths
+                // Apply default derivation paths if provided.
+                // Three input shapes are supported by getDefaultDerivationPaths():
+                //   1. String          → single path on Secp256k1 (legacy / XRP-style behaviour)
+                //   2. Array<String>   → multiple paths on Secp256k1
+                //   3. Map             → multi-curve, multi-path mapping
+                //                        e.g. { "ed25519_slip0010": ["m/44'/3030'/0'/0'/0'", ...] }
+                //                        Required for chains that use non-secp256k1 derivation
+                //                        (e.g. Hedera uses SLIP-0010 ED25519).
+                val multiCurvePaths = optionsParser.getDefaultDerivationPaths()
+                if (multiCurvePaths != null && multiCurvePaths.isNotEmpty()) {
+                    config.defaultDerivationPaths = multiCurvePaths.toMutableMap()
                 }
                 // set the new config to the SDK
                 sdk.config = config
@@ -581,10 +585,141 @@ class OptionsParser(private val options: ReadableMap?) {
     }
 
     fun getDefaultDerivationPath(): DerivationPath? {
+        // Legacy single-path accessor (kept for backwards compatibility with callers
+        // that only need secp256k1; the multi-curve path goes via getDefaultDerivationPaths).
         val defaultPath = options?.getString("defaultDerivationPaths")
         if (defaultPath.isNullOrEmpty()) {
             return null
         }
         return DerivationPath(rawPath = defaultPath)
+    }
+
+    /**
+     * Resolve a JS-side curve name (e.g. "ed25519_slip0010", "secp256k1") to the SDK enum.
+     *
+     * Strategy:
+     *   1. Explicit hardcoded mapping for known Tangem-Android SDK enum names (PascalCase).
+     *      This is the **primary, safest** path — reflection-free, deterministic.
+     *   2. Heuristic name-variant probing (snake_case, PascalCase, lowercase, etc.).
+     *      Fallback for SDK versions where enum names diverge from our hardcoded list.
+     *   3. Brute-force scan via `EllipticCurve.values()` matching by name/toString().
+     *
+     * Returns null if no match — caller skips that curve silently.
+     */
+    private fun resolveCurve(jsName: String): EllipticCurve? {
+        val normalized = jsName.lowercase()
+
+        // Strategy 1: explicit known mappings (deterministic, no reflection surprises).
+        // Maps JS rawValue (lowercase snake_case, matches iOS EllipticCurve.swift) to
+        // the Tangem-android Kotlin enum name (PascalCase, observed in v3.9.2 source).
+        val explicitKotlinName: String? = when (normalized) {
+            "secp256k1" -> "Secp256k1"
+            "secp256r1" -> "Secp256r1"
+            "ed25519" -> "Ed25519"
+            "ed25519_slip0010" -> "Ed25519Slip0010"
+            "bip0340" -> "Bip0340"
+            "bls12381_g2" -> "Bls12381G2"
+            "bls12381_g2_aug" -> "Bls12381G2Aug"
+            "bls12381_g2_pop" -> "Bls12381G2Pop"
+            else -> null
+        }
+        if (explicitKotlinName != null) {
+            runCatching { EllipticCurve.valueOf(explicitKotlinName) }.getOrNull()?.let { return it }
+        }
+
+        // Strategy 2: heuristic name-variant probing (covers SDK refactors where the
+        // enum naming convention diverges from our hardcoded map above).
+        val variants = mutableSetOf(
+            jsName,
+            jsName.lowercase(),
+            jsName.uppercase(),
+            // snake_case → PascalCase: "ed25519_slip0010" → "Ed25519Slip0010"
+            jsName.split('_').joinToString("") { part ->
+                part.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+            },
+            // First-letter capitalised: "secp256k1" → "Secp256k1"
+            jsName.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
+            // Strip underscores: "ed25519_slip0010" → "Ed25519slip0010"
+            jsName.replace("_", "").replaceFirstChar {
+                if (it.isLowerCase()) it.titlecase() else it.toString()
+            }
+        )
+        for (variant in variants) {
+            runCatching { EllipticCurve.valueOf(variant) }.getOrNull()?.let { return it }
+        }
+
+        // Strategy 3: brute-force scan all entries case-insensitively.
+        val match = EllipticCurve.values().firstOrNull { entry ->
+            entry.name.equals(jsName, ignoreCase = true) ||
+                entry.toString().equals(jsName, ignoreCase = true) ||
+                entry.name.replace("_", "").equals(jsName.replace("_", ""), ignoreCase = true)
+        }
+        if (match == null) {
+            android.util.Log.w(
+                "RNTangemSdk",
+                "resolveCurve: no EllipticCurve match for JS curve name \"$jsName\""
+            )
+        }
+        return match
+    }
+
+    /**
+     * Multi-curve, multi-path derivation paths.
+     * Accepts a ReadableMap with curve-name keys mapping to ReadableArrays of raw path strings:
+     *   { "ed25519_slip0010": ["m/44'/3030'/0'/0'/0'", ...], "secp256k1": [...] }
+     * Also accepts a single string (legacy: maps to Secp256k1) and a single array of strings
+     * (assumed Secp256k1 for backwards compatibility).
+     * Unknown curve names and unparseable paths are silently skipped, never throw.
+     */
+    fun getDefaultDerivationPaths(): Map<EllipticCurve, List<DerivationPath>>? {
+        if (options == null || !options.hasKey("defaultDerivationPaths")) return null
+
+        val type = options.getType("defaultDerivationPaths")
+
+        // Shape 1: Map { curveName: [pathString, ...] }
+        if (type == ReadableType.Map) {
+            val dict = options.getMap("defaultDerivationPaths") ?: return null
+            val result = mutableMapOf<EllipticCurve, List<DerivationPath>>()
+            val iter = dict.keySetIterator()
+            while (iter.hasNextKey()) {
+                val curveName = iter.nextKey()
+                val curve = resolveCurve(curveName) ?: continue
+                if (dict.getType(curveName) != ReadableType.Array) continue
+                val arr = dict.getArray(curveName) ?: continue
+                val paths = mutableListOf<DerivationPath>()
+                for (i in 0 until arr.size()) {
+                    if (arr.getType(i) != ReadableType.String) continue
+                    val raw = arr.getString(i) ?: continue
+                    runCatching { DerivationPath(rawPath = raw) }.getOrNull()?.let { paths.add(it) }
+                }
+                if (paths.isNotEmpty()) {
+                    result[curve] = paths
+                }
+            }
+            return if (result.isEmpty()) null else result
+        }
+
+        // Shape 2: Array of path strings — assumed Secp256k1 (legacy)
+        if (type == ReadableType.Array) {
+            val arr = options.getArray("defaultDerivationPaths") ?: return null
+            val paths = mutableListOf<DerivationPath>()
+            for (i in 0 until arr.size()) {
+                if (arr.getType(i) != ReadableType.String) continue
+                val raw = arr.getString(i) ?: continue
+                runCatching { DerivationPath(rawPath = raw) }.getOrNull()?.let { paths.add(it) }
+            }
+            return if (paths.isEmpty()) null else mapOf(EllipticCurve.Secp256k1 to paths)
+        }
+
+        // Shape 3: Single path string — assumed Secp256k1 (legacy v3.1.0 behaviour)
+        if (type == ReadableType.String) {
+            val raw = options.getString("defaultDerivationPaths") ?: return null
+            if (raw.isEmpty()) return null
+            return runCatching { DerivationPath(rawPath = raw) }
+                .getOrNull()
+                ?.let { mapOf(EllipticCurve.Secp256k1 to listOf(it)) }
+        }
+
+        return null
     }
 }

--- a/ios/SwiftTangemSdkPluging.swift
+++ b/ios/SwiftTangemSdkPluging.swift
@@ -25,9 +25,16 @@ import TangemSdk
                 if let attestationMode = optionsParser.getAttestationMode() {
                     config.attestationMode = attestationMode
                 }
-                // set default derivationPaths
-                if let defaultDerivationPath = optionsParser.getDefaultDerivationPath() {
-                    config.defaultDerivationPaths[.secp256k1] = [defaultDerivationPath]
+                // Apply default derivation paths if provided.
+                // Three input shapes are supported by getDefaultDerivationPaths():
+                //   1. String          → single path on .secp256k1 (legacy / XRP-style behaviour)
+                //   2. Array<String>   → multiple paths on .secp256k1
+                //   3. Dictionary      → multi-curve, multi-path mapping
+                //                        e.g. { "ed25519_slip0010": ["m/44'/3030'/0'/0'/0'", ...] }
+                //                        Required for chains that use non-secp256k1 derivation
+                //                        (e.g. Hedera uses SLIP-0010 ED25519).
+                if let defaultPaths = optionsParser.getDefaultDerivationPaths(), !defaultPaths.isEmpty {
+                    config.defaultDerivationPaths = defaultPaths
                 }
                 // set the new config to the SDK
                 self.sdk.config = config
@@ -364,6 +371,69 @@ class OptionsParser {
         if let defaultPath = self.options?.object(forKey: "defaultDerivationPaths") as? String {
             return try? DerivationPath(rawPath: defaultPath)
         }
+        return nil
+    }
+
+    /// Case-insensitive resolver for EllipticCurve rawValues.
+    /// Tangem's EllipticCurve enum rawValues are lowercase snake_case (e.g. "ed25519_slip0010"),
+    /// but JS callers may send uppercase or mixed case. We accept both.
+    private func resolveCurve(_ jsName: String) -> EllipticCurve? {
+        // Try direct match first (fast path for correctly-cased input)
+        if let curve = EllipticCurve(rawValue: jsName) {
+            return curve
+        }
+        // Fallback: case-insensitive scan of all enum cases
+        let lower = jsName.lowercased()
+        if let curve = EllipticCurve(rawValue: lower) {
+            return curve
+        }
+        let match = EllipticCurve.allCases.first { $0.rawValue.lowercased() == lower }
+        if match == nil {
+            NSLog("[RNTangemSdk] resolveCurve: no EllipticCurve match for JS curve name \"\(jsName)\"")
+        }
+        return match
+    }
+
+    /// Multi-curve, multi-path derivation paths.
+    /// Accepts an NSDictionary with curve-name keys mapping to arrays of raw path strings:
+    ///   { "ed25519_slip0010": ["m/44'/3030'/0'/0'/0'", ...], "secp256k1": [...] }
+    /// Also accepts a single string (legacy: maps to .secp256k1) and a single array of strings
+    /// (assumed .secp256k1 for backwards compatibility).
+    /// Unknown curve names and unparseable paths are silently skipped, never throw.
+    func getDefaultDerivationPaths() -> [EllipticCurve: [DerivationPath]]? {
+        guard let raw = self.options?.object(forKey: "defaultDerivationPaths") else {
+            return nil
+        }
+
+        // Shape 1: Dictionary { curveName: [pathString, ...] }
+        if let dict = raw as? NSDictionary {
+            var result: [EllipticCurve: [DerivationPath]] = [:]
+            for (key, value) in dict {
+                guard let curveName = key as? String,
+                      let curve = resolveCurve(curveName),
+                      let pathStrings = value as? [String] else {
+                    continue
+                }
+                let paths: [DerivationPath] = pathStrings.compactMap { try? DerivationPath(rawPath: $0) }
+                if !paths.isEmpty {
+                    result[curve] = paths
+                }
+            }
+            return result.isEmpty ? nil : result
+        }
+
+        // Shape 2: Array of path strings — assumed secp256k1 (legacy)
+        if let pathStrings = raw as? [String] {
+            let paths: [DerivationPath] = pathStrings.compactMap { try? DerivationPath(rawPath: $0) }
+            return paths.isEmpty ? nil : [.secp256k1: paths]
+        }
+
+        // Shape 3: Single path string — assumed secp256k1 (legacy v3.1.0 behaviour)
+        if let singlePath = raw as? String,
+           let derivation = try? DerivationPath(rawPath: singlePath) {
+            return [.secp256k1: [derivation]]
+        }
+
         return nil
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,28 @@ export enum EllipticCurve {
   Secp256k1 = "secp256k1",
   Secp256r1 = "secp256r1",
   Ed25519 = "ed25519",
+  Ed25519Slip0010 = "ed25519_slip0010",
+  Bip0340 = "bip0340",
+  Bls12381G2 = "bls12381_G2",
+  Bls12381G2Aug = "bls12381_G2_AUG",
+  Bls12381G2Pop = "bls12381_G2_POP",
 }
+
+/**
+ * Multi-curve, multi-path derivation map for `defaultDerivationPaths`.
+ * Keys are {@link EllipticCurve} raw values; values are arrays of raw derivation
+ * path strings. Enables HD-wallet auto-derivation on curves other than secp256k1.
+ *
+ * @example
+ *   // Hedera (SLIP-0010 ED25519 on BIP-44 coin-type 3030):
+ *   {
+ *     "ed25519_slip0010": [
+ *       "m/44'/3030'/0'/0'/0'",
+ *       "m/44'/3030'/0'/0'/1'"
+ *     ]
+ *   }
+ */
+export type DefaultDerivationPathsMap = Partial<Record<`${EllipticCurve}`, string[]>>;
 
 export enum LinkedTerminalStatus {
   Current = "current",
@@ -391,11 +412,32 @@ export interface OptionsStartSession extends OptionsCommon {
    */
   attestationMode?: "full" | "nomral" | "offline";
   /**
-   * A card with HD wallets feature enabled will derive keys automatically on "scan" and "createWallet". Repeated items will be ignored
-   * All derived keys will be stored in `Card.Wallet.derivedKeys`.
-   * Only `secp256k1` and `ed25519` supported
+   * On cards with the HD-wallet feature enabled, derives keys automatically during
+   * `scanCard` and `createWallet`. Repeated items are ignored. All derived keys are
+   * stored in `Card.Wallet.derivedKeys`.
+   *
+   * Three input shapes are accepted by the native bridge:
+   *
+   *   1. `string`
+   *      Single derivation path; applied to the `secp256k1` curve. This preserves
+   *      the original v3.1.0 behaviour for existing XRP-style callers.
+   *
+   *   2. `string[]`
+   *      Multiple derivation paths; all applied to the `secp256k1` curve.
+   *
+   *   3. {@link DefaultDerivationPathsMap}
+   *      Multi-curve, multi-path mapping. Required for chains that use a curve
+   *      other than `secp256k1`, e.g. Hedera (SLIP-0010 ED25519).
+   *
+   * @example
+   *   // Hedera — 16 accounts on BIP-44 coin-type 3030 (SLIP-0010 ED25519):
+   *   await RNTangemSdk.startSession({
+   *     defaultDerivationPaths: {
+   *       "ed25519_slip0010": Array.from({length: 16}, (_, i) => `m/44'/3030'/0'/0'/${i}'`)
+   *     }
+   *   });
    */
-  defaultDerivationPaths?: string;
+  defaultDerivationPaths?: string | string[] | DefaultDerivationPathsMap;
 }
 
 export type RNTangemSdkModule = {


### PR DESCRIPTION
## Summary

Extends `startSession`'s `defaultDerivationPaths` from a single `string` to a union of three shapes, enabling HD-wallet auto-derivation on curves other than `secp256k1`. The original behaviour is preserved 1:1 for existing callers.

## Motivation

The native bridges currently hardcode `defaultDerivationPaths` to `secp256k1`:

- **iOS** ([`SwiftTangemSdkPluging.swift:30`](https://github.com/XRPL-Labs/tangem-sdk-react-native/blob/main/ios/SwiftTangemSdkPluging.swift#L30)): `config.defaultDerivationPaths[.secp256k1] = [defaultDerivationPath]`
- **Android** ([`RNTangemSdkModule.kt:180`](https://github.com/XRPL-Labs/tangem-sdk-react-native/blob/main/android/src/main/java/com/tangem/RNTangemSdk/RNTangemSdkModule.kt#L180)): `defaultDerivationPaths[EllipticCurve.Secp256k1] = listOf(defaultDerivationPath)`

This prevents auto-derivation on cards that use other curves. The most visible blocker is **Hedera** (HBAR / HTS), which uses `ed25519_slip0010` on BIP-44 coin-type `3030` (`m/44'/3030'/0'/0'/N'`). Without this change, `card.wallets[].derivedKeys` stays empty after `scanCard()` even when the path config is provided, because the JS-side path never reaches the matching curve in `Config.defaultDerivationPaths`.

The underlying `TangemSdk` cores (iOS Pod `3.11.0`, Android `3.9.2`) already expose `EllipticCurve.ed25519_slip0010` and the rest of the curve set — only this RN wrapper was blocking it.

## API change

`OptionsStartSession.defaultDerivationPaths` is widened to:

| Shape                            | Curve applied | Use case                                  |
| -------------------------------- | ------------- | ----------------------------------------- |
| `string`                         | `secp256k1`   | Single path — XRP / BTC style (legacy)    |
| `string[]`                       | `secp256k1`   | Multiple paths on the same curve          |
| `DefaultDerivationPathsMap`      | Per-curve     | Multi-curve — e.g. ED25519 / SLIP-0010    |

```ts
type DefaultDerivationPathsMap = Partial<Record<`${EllipticCurve}`, string[]>>;
```

### Hedera example

```js
const hederaPaths = Array.from(
    { length: 16 },
    (_, i) => `m/44'/3030'/0'/0'/${i}'`,
);

await RNTangemSdk.startSession({
    attestationMode: "offline",
    defaultDerivationPaths: { ed25519_slip0010: hederaPaths },
});

const card = await RNTangemSdk.scanCard();
// card.wallets[i].derivedKeys now contains all 16 derived ED25519 keys.
```

## Implementation notes

**iOS** (`ios/SwiftTangemSdkPluging.swift`)
- New `getDefaultDerivationPaths()` on `OptionsParser` returning `[EllipticCurve: [DerivationPath]]?`
- Handles all three input shapes (NSString, NSArray, NSDictionary)
- Case-insensitive `resolveCurve(_:)` tolerates JS-side casing variations
- Unparseable paths and unknown curve names are silently skipped, never throw (consistent with the existing `try?` style)
- Original `getDefaultDerivationPath()` is preserved for binary compatibility

**Android** (`android/.../RNTangemSdkModule.kt`)
- Mirror of the iOS implementation in Kotlin
- Multi-strategy `resolveCurve(...)` with three layers:
  1. Explicit hardcoded mapping for the current SDK enum names (deterministic primary)
  2. Heuristic name-variant probing (snake_case ↔ PascalCase, etc.)
  3. Brute-force scan via `EllipticCurve.values()`
- This belt-and-suspenders approach keeps the patch resilient if the upstream Kotlin SDK ever renames its enum constants
- A `Log.w` is emitted when a curve name can't be resolved, to help downstream debugging

**TypeScript** (`src/types.ts`)
- `EllipticCurve` enum extended with all curves currently supported by the Tangem SDK cores (`ed25519_slip0010`, `bip0340`, `bls12381_*`)
- New `DefaultDerivationPathsMap` type
- `OptionsStartSession.defaultDerivationPaths` widened to the union shape
- JSDoc updated with a Hedera example

**README**
- `startSession` section now documents all three shapes with a comparison table and a Hedera derivation example.

## Backwards compatibility

100% backwards-compatible. Both native bridges first inspect the JS-side value type:

- A bare string still maps to `.secp256k1` exactly as in `v3.1.0`.
- An array of strings is a new convenience for the same curve.
- A dictionary is the new path; callers opt in by passing this shape.

Existing apps continue to work without source changes.

## Testing

Verified end-to-end against a Hedera-configured Tangem card on iOS:

- `startSession({ defaultDerivationPaths: { ed25519_slip0010: [...16 paths] } })` followed by `scanCard()` returns `card.wallets[i].derivedKeys` populated with all 16 derived ED25519 public keys, matching the Hedera Mirror Node accounts in our deployment.
- Legacy `defaultDerivationPaths: "m/44'/144'/0'/0/0"` (the example currently in the README) still derives the secp256k1 key as before, confirming the legacy shape regression-free.

Android changes mirror the iOS implementation and were verified to compile against the existing `com.github.tangem.tangem-sdk-android:core:3.9.2`. Runtime testing on Android requires a Java/Android dev environment which I don't have set up locally; happy to extend with a unit test if the maintainers prefer that route.

## Context

This patch is the result of debugging an integration with Tangem cards holding Hedera HTS accounts (`m/44'/3030'/...` derivation) for a MiCA-conformant utility-token project. Without the change, the only workaround on Hedera was per-path NFC taps via `sign()` with `derivationPath`, which is impractical for any card with more than a couple of accounts.

If the change isn't a fit upstream as-is, happy to iterate on the API shape, naming, comment style, or scope. I'm also fine splitting iOS/Android into separate PRs if that's the preferred review flow.

cc the Hedera RN community — this also unblocks Tangem usage for any other ED25519-based chain on the SDK.